### PR TITLE
Update so that synm.str_low is no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ If you already have a miniconda or anaconda Python 3.X environment:
  - `conda install openpyxl`
  - `conda install pandas`
  - `pip install git+https://github.com/usgs/finite-fault-product.git`
- 
+
  Automatic environment creation using miniconda:
- 
+
  - `git clone https://github.com/usgs/finite-fault-product.git`
  - `cd finite-fault-product`
  - `bash install.sh`
@@ -38,7 +38,8 @@ If you already have a miniconda or anaconda Python 3.X environment:
 ## Updating
 
 Updating automated install:
-- `cd shakemap-amp-tools`
+- `cd finite-fault-product`
+- `conda activate faultproduct`
 - `git pull --ff-only https://github.com/usgs/finite-fault-product.git master`
 - `bash install.sh`
 

--- a/docs/web_product.md
+++ b/docs/web_product.md
@@ -80,7 +80,7 @@ Failure to include these files will result in an error
     <td>Readlp.das</td>
   </tr>
   <tr>
-    <td colspan="3">* These files may be substituted with a wave_properties.json file. See the example below.</td>
+    <td colspan="3">* These files may be substituted with a wave_properties.json file. `synm.str_low` may also be excluded if there are no surface waves. See the example below.</td>
   </tr>
 </table>
 
@@ -144,6 +144,14 @@ These files are note required, but are recommended and will be looked for.
 
 Note: If waveplots.zip is not included but plot images are (files with the pattern "*wave_*.png"), a zip file will be created for these images.
 
+Example of wave_properties.json:
+<pre>
+{
+  "num_longwaves": 72,
+  "num_pwaves": 50,
+  "num_shwaves": 17
+}
+</pre>
 
 ## File name changes
 File names are standardized for each event.

--- a/product/web_product.py
+++ b/product/web_product.py
@@ -363,15 +363,6 @@ class WebProduct(object):
             eventid (string): Eventid used for file naming. Default is empty
                     string.
             version (int): Product version number. Default is 1.
-            pwaves (int): Number of teleseismic broadband P waveforms. Default
-                    is None.
-            shwaves (int): Number of broadband SH waveforms. Default is None.
-            longwaves (int): Number of long period surface waves selected
-                    based on data quality and azimuthal distribution. Default
-                    is None.
-        Notes:
-            pwaves, shwaves, longwaves should only be used when U.S.G.S.
-            specific files (synm.str_low and Readlp.das) are not included.
 
         Returns:
             WebProduct: Instance set for information for the web product.
@@ -482,6 +473,8 @@ class WebProduct(object):
                     props['number-longwaves'] = int(f.readline().strip())
             except:
                 props['number-longwaves'] = 0
+        elif not os.path.exists(os.path.join(directory, 'wave_properties.json')):
+            props['number-longwaves'] = 0
         URL_TEMPLATE = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/detail/[EVENTID].geojson'
         url = URL_TEMPLATE.replace('[EVENTID]', 'us'+eventid)
         try:
@@ -727,7 +720,6 @@ class WebProduct(object):
                 'Base Map PNG': '*base*.png',
                 'Slip PNG': '*slip*.png',
                 'FSP File': '*.fsp',
-                'Low File': 'synm.str_low',
                 'Wave File': 'Readlp.das'
             }
         unavailable = []


### PR DESCRIPTION
If synm.str_low and wave_properties.json are not included in the directory, number-longwaves is set to 0.