### PR TITLE
Delete preexisting folders to prevent conflicts

### DIFF
--- a/bin/sendproduct
+++ b/bin/sendproduct
@@ -63,12 +63,18 @@ def main(args):
         ffm2dir = args.ffm2
         product2 = WebProduct.fromDirectory(ffm2dir, args.eventid,
                 version=version)
-        os.makedirs(pdlfolder2, exist_ok=True)
+        # overwrite the folder to stop conflicts
+        if os.path.exists(pdlfolder2):
+            shutil.rmtree(pdlfolder2)
+        os.makedirs(pdlfolder2)
         copy_files(product2.paths, pdlfolder2)
         folders += pdlfolder2 + ' and '
     else:
         pdlfolder1 = os.path.join(BASE_PDL_FOLDER, args.eventid)
-    os.makedirs(pdlfolder1, exist_ok=True)
+    # overwrite the folder to stop conflicts
+    if os.path.exists(pdlfolder1):
+        shutil.rmtree(pdlfolder1)
+    os.makedirs(pdlfolder1)
     copy_files(product1.paths, pdlfolder1)
     folders += pdlfolder1
 


### PR DESCRIPTION
Deleted existing folders to prevent send conflicts. For example, previously if the an event was sent twice (`sendproduct us us 1000dyad <EVENT_DIRECTORY>`), wherein the first sent included a file and the second excluded the file in the EVENT_DIRECTORY, the original file would still remain in the pdlout folder. This removes the past directory before copying over the new files to prevent this.